### PR TITLE
Bugfix for Issue #13

### DIFF
--- a/examples/library/library.lua
+++ b/examples/library/library.lua
@@ -1,4 +1,7 @@
 print(testlib.Empty())
 print(testlib.BasicParams(3, 4.2, "hello", true))
+print(testlib.BasicParams(nil, nil, nil, nil))
 print("Basic ret:", testlib.BasicRet())
 print(testlib.StructParam({A=5, B=2}))
+print(testlib.StructParam({A=nil, B=nil}))
+print(testlib.StructParam(nil))

--- a/luna_test.go
+++ b/luna_test.go
@@ -193,6 +193,45 @@ func TestCreateLibrary(t *testing.T) {
 	}
 }
 
+func TestLibraryCallWithNilValues(t *testing.T) {
+	fun := func(vali int, valf float32, vals string, valb bool) (int, float32, string, bool) {
+		return vali, valf, vals, valb
+	}
+
+	l := New(LibBase)
+	libMembers := []TableKeyValue{
+		{"fun", fun},
+	}
+	err := l.CreateLibrary("testlib", libMembers...)
+	if err != nil {
+		t.Fatal("Error creating library:", err)
+	}
+	ret, err := l.Load("testlib.fun(nil, nil, nil, nil)")
+	if err != nil {
+		t.Error("Error loading test lua code:", err)
+	}
+	var (
+		i int
+		f float32
+		s string
+		b bool
+	)
+	ret.Unmarshal(&i, &f, &s, &b)
+
+	if i != 0 {
+		t.Errorf("Return value do not match: %d != 0", i)
+	}
+	if f != 0 {
+		t.Errorf("Return value do not match: %f != 0", f)
+	}
+	if s != "" {
+		t.Errorf("Return value do not match: %s != ''", s)
+	}
+	if b != false {
+		t.Errorf("Return value do not match: %t != false", b)
+	}
+}
+
 func TestInvalidLibrary(t *testing.T) {
 	l := New(LibBase)
 	libMembers := []TableKeyValue{
@@ -622,7 +661,11 @@ end`
 	if err != nil {
 		t.Fatal("Error loading library:", err)
 	}
+
 	_, err = l.Call("callMe")
+	if err == nil || err.Error() != "Wrong type" {
+		t.Fatal("Error call to invalid Lua to Go function does not lead to an error:", err)
+	}
 }
 
 func TestReturns(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -25,11 +25,11 @@ func printGen(w io.Writer) func(...string) {
 func wrapperGen(l *Luna, impl reflect.Value) lua.LuaGoFunction {
 	typ := impl.Type()
 	params := make([]reflect.Value, typ.NumIn())
-	for i := range params {
-		params[i] = reflect.New(typ.In(i)).Elem()
-	}
 
 	return func(L *lua.State) int {
+		for i := range params {
+			params[i] = reflect.New(typ.In(i)).Elem()
+		}
 		args := L.GetTop()
 		if args < len(params) {
 			panic(fmt.Sprintf("Args: %d, Params: %d", args, len(params)))
@@ -50,7 +50,9 @@ func wrapperGen(l *Luna, impl reflect.Value) lua.LuaGoFunction {
 				// ignore extra args
 				break
 			} else {
-				l.set(params[i-1], i)
+				if err := l.set(params[i-1], i); err != nil {
+					panic(err)
+				}
 			}
 		}
 


### PR DESCRIPTION
Nil values are not supported by go for basic types. Therfore if lua passes
nil values as arguments to go functions, go now uses the "default values"
for variables (e.g. 0 for int, false for bool, "" for string).

Modified handling for argument types which are not currently supported.
In this case a panic is raised, which is recovered by the "call" function, which allows
to return a proper error (via chan).

Bugfix for https://github.com/beatgammit/luna/issues/13
